### PR TITLE
Use `assignees` instead of `assignee` in option parameters

### DIFF
--- a/app/models/events/base.rb
+++ b/app/models/events/base.rb
@@ -5,7 +5,7 @@ module Events
     private
 
     def update_pull_request
-      client.update_issue("#{organization_name}/#{repository_name}", pull_request_number, assignee: new_assignee)
+      client.update_issue("#{organization_name}/#{repository_name}", pull_request_number, assignees: new_assignees)
     rescue Octokit::NotFound
       puts "Does #{team_name} have 'write' permission?"
     end
@@ -22,8 +22,8 @@ module Events
       @candidates ||= client.team_members(team.id, { per_page: 100 }).map(&:login) - [creator]
     end
 
-    def new_assignee
-      candidates.sample
+    def new_assignees
+      Array(candidates.sample)
     end
 
     def repository_name

--- a/app/models/events/issue_comment.rb
+++ b/app/models/events/issue_comment.rb
@@ -11,7 +11,7 @@ module Events
     def hook
       return unless payload
       return unless team_name
-      return unless new_assignee
+      return unless new_assignees
 
       update_pull_request
     end

--- a/app/models/events/pull_request.rb
+++ b/app/models/events/pull_request.rb
@@ -15,7 +15,7 @@ module Events
       return if wip?
       return if assignee
       return unless team_name
-      return unless new_assignee
+      return unless new_assignees
 
       update_pull_request
     end
@@ -30,8 +30,8 @@ module Events
       payload.dig('pull_request', 'title') =~ /\A(?:WIP|\(WIP\)|\[WIP\])/i
     end
 
-    def new_assignee
-      candidates.sample
+    def new_assignees
+      Array(candidates.sample)
     end
 
     def assignee

--- a/test/models/events/issue_comment_test.rb
+++ b/test/models/events/issue_comment_test.rb
@@ -22,7 +22,7 @@ class Events::IssueCommentTest < MiniTest::Test
     client = mock('Octokit::Client')
     client.expects(:organization_teams).returns([OpenStruct.new(name: 'sandbox', id: 12345), OpenStruct.new(name: 'tech_team', id: 12346)])
     client.expects(:team_members).with(12346, { per_page: 100 }).returns([OpenStruct.new(login: 'ppworks'), OpenStruct.new(login: 'ppworks3')])
-    client.expects(:update_issue).with('genuineblue/sandbox', 1, assignee: 'ppworks3')
+    client.expects(:update_issue).with('genuineblue/sandbox', 1, assignees: ['ppworks3'])
     Octokit::Client.expects(:new).with(access_token: ENV.fetch('GITHUB_API_TOKEN')).returns(client)
 
     Events::IssueComment.new(payload: payload).hook

--- a/test/models/events/pull_request_test.rb
+++ b/test/models/events/pull_request_test.rb
@@ -20,7 +20,7 @@ class Events::PullRequestTest < MiniTest::Test
     client = mock('Octokit::Client')
     client.expects(:organization_teams).returns([OpenStruct.new(name: 'sandbox', id: 12345)])
     client.expects(:team_members).with(12345, { per_page: 100 }).returns([OpenStruct.new(login: 'ppworks'), OpenStruct.new(login: 'ppworks2')])
-    client.expects(:update_issue).with('genuineblue/sandbox', 1, assignee: 'ppworks2')
+    client.expects(:update_issue).with('genuineblue/sandbox', 1, assignees: ['ppworks2'])
     Octokit::Client.expects(:new).with(access_token: ENV.fetch('GITHUB_API_TOKEN')).returns(client)
 
     Events::PullRequest.new(payload: payload).hook
@@ -46,7 +46,7 @@ class Events::PullRequestTest < MiniTest::Test
     client = mock('Octokit::Client')
     client.expects(:organization_teams).returns([OpenStruct.new(name: 'sandbox', id: 12345), OpenStruct.new(name: 'tech_team', id: 12346)])
     client.expects(:team_members).with(12346, { per_page: 100 }).returns([OpenStruct.new(login: 'ppworks'), OpenStruct.new(login: 'ppworks3')])
-    client.expects(:update_issue).with('genuineblue/sandbox', 1, assignee: 'ppworks3')
+    client.expects(:update_issue).with('genuineblue/sandbox', 1, assignees: ['ppworks3'])
     Octokit::Client.expects(:new).with(access_token: ENV.fetch('GITHUB_API_TOKEN')).returns(client)
 
     Events::PullRequest.new(payload: payload).hook


### PR DESCRIPTION
The key named `assignee` in option parameters is deprecated.
see:
  https://developer.github.com/v3/issues/#edit-an-issue
  https://github.com/octokit/octokit.rb/blob/v4.6.2/lib/octokit/client/issues.rb#L197

(cherry picked from commit 6a0b33ef4d18939a3313743eb31c0b86a526d4e8)
